### PR TITLE
docs: 修复 README 中 Star 趋势图无法显示的问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Or support via Ko-fi: [ko-fi.com/yeheboo](https://ko-fi.com/yeheboo)
 
 ## 📈 Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=jiweiyeah/skills-manager&type=Date)](https://star-history.com/#jiweiyeah/skills-manager&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=jiweiyeah/skills-manager&type=Date)](https://star-history.dera.page/#jiweiyeah/skills-manager&Date)
 
 ---
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -105,7 +105,7 @@ WEBKIT_DISABLE_COMPOSITING_MODE=1 ./Skills-Manager_<version>_amd64.AppImage
 
 ## 📈 Star 趋势图
 
-[![Star History Chart](https://api.star-history.com/svg?repos=jiweiyeah/skills-manager&type=Date)](https://star-history.com/#jiweiyeah/skills-manager&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=jiweiyeah/skills-manager&type=Date)](https://star-history.dera.page/#jiweiyeah/skills-manager&Date)
 
 ---
 


### PR DESCRIPTION
README 中的 Star 趋势图目前因 GitHub API 限制而无法正常展示，这会直接影响项目页面的观感与可信度。此次更新将趋势图切换到可用的数据源，确保 Star 趋势图能够正常加载，同时同步修复了中文版 README。